### PR TITLE
Added cookies to facilitate autoloading

### DIFF
--- a/smart-tabs-mode.el
+++ b/smart-tabs-mode.el
@@ -15,6 +15,18 @@
 ;;  (add-hook 'MODE-HOOK 'smart-tabs-mode-enable)
 ;;  (smart-tabs-advice INDENT-FUNC TAB-WIDTH-VAR)
 ;;
+;; Note that it might be preferable to delay calling smart-tabs-advice
+;; until after the major mode is loaded and evaluated:
+;;
+;; (eval-after-load 'MODE-FEATURE
+;;   '(smart-tabs-advice INDENT-FUNC TAB-WIDTH-VAR))
+;;
+;; Or:
+;;
+;;  (add-hook 'MODE-HOOK (lambda ()
+;;                         (smart-tabs-mode-enable)
+;;                         (smart-tabs-advice INDENT-FUNC TAB-WIDTH-VAR)))
+;;
 ;; Here are some specific examples for a few popular languages:
 ;;
 ;;  ;; C/C++


### PR DESCRIPTION
Added autoload cookies to the functions and macros in smart-tabs-mode.el

I don't think that smart-tabs-advice should have a cookie, since ideally (at least to me) it would be evaluated in a mode hook or eval-after-load form after smart-tabs-mode(-enable) is called.
However I decided to be consistent with the documentation, which doesn't use such a format.
