### PR TITLE
Define an utility function to enable smarttabs for popular languages

### DIFF
--- a/smart-tabs-mode.el
+++ b/smart-tabs-mode.el
@@ -3,13 +3,15 @@
 ;; Copyright © 2011 John Croisant <jacius@gmail.com>
 ;; Copyright © 2011 Joel C. Salomon <joelcsalomon@gmail.com>
 ;; Copyright © 2012 Alan Pearce <alan@alanpearce.co.uk>
+;; Copyright © 2012 Daniel Dehennin <daniel.dehennin@baby-gnu.org>
 
 ;; Author: John Croisant <jacius@gmail.com>
 ;;         Joel C. Salomon <joelcsalomon@gmail.com>
 ;;         Alan Pearce <alan@alanpearce.co.uk>
+;;         Daniel Dehennin <daniel.dehennin@baby-gnu.org>
 ;; URL: http://www.emacswiki.org/emacs/SmartTabs
 ;; Created: 19 Sep 2011
-;; Version: 0.1
+;; Version: 0.2
 ;; Keywords: languages
 
 ;; This file is not part of GNU Emacs.
@@ -62,7 +64,11 @@
 ;;                         (smart-tabs-mode-enable)
 ;;                         (smart-tabs-advice INDENT-FUNC TAB-WIDTH-VAR)))
 ;;
-;; Here are some specific examples for a few popular languages:
+;; Here are some specific examples for a few popular languages which
+;; can be enabled by 'smart-tab-insinuate':
+;;
+;;  ;; Load all the following in one pass
+;;  (smart-tabs-insinuate 'c 'javascript 'cperl 'python 'ruby)
 ;;
 ;;  ;; C/C++
 ;;  (add-hook 'c-mode-hook 'smart-tabs-mode-enable)
@@ -94,6 +100,47 @@
 ;;; Code:
 
 (require 'advice)
+
+(defvar smart-tabs-mode-map
+  '((c . (lambda ()
+           (add-hook 'c-mode-hook
+                     (lambda ()
+                       (smart-tabs-mode-enable)
+                       (smart-tabs-advice c-indent-line c-basic-offset)
+                       (smart-tabs-advice c-indent-region c-basic-offset)))))
+    (javascript . (lambda ()
+                    (add-hook 'js2-mode-hook
+                              (lambda ()
+                                (smart-tabs-mode-enable)
+                                (smart-tabs-advice js2-indent-line js2-basic-offset)))))
+    (cperl . (lambda ()
+               (add-hook 'cperl-mode-hook
+                         (lambda ()
+                           (smart-tabs-mode-enable)
+                           (smart-tabs-advice cperl-indent-line cperl-indent-level)))))
+    (python . (lambda ()
+                (add-hook 'python-mode-hook
+                          (lambda ()
+                            (smart-tabs-mode-enable)
+                            (smart-tabs-advice python-indent-line-1 python-indent)
+                            (if (featurep 'python-mode)
+                                (progn
+                                  (smart-tabs-advice py-indent-line py-indent-offset)
+                                  (smart-tabs-advice py-newline-and-indent py-indent-offset)
+                                  (smart-tabs-advice py-indent-region py-indent-offset)))))))
+    (ruby . (lambda ()
+              (add-hook 'ruby-mode-hook
+                        (lambda ()
+                          (smart-tabs-mode-enable)
+                          (smart-tabs-advice ruby-indent-line ruby-indent-level)))))
+    (nxml . (lambda ()
+              (add-hook 'nxml-mode-hook
+                        (lambda ()
+                          (smart-tabs-mode-enable)
+                          (smart-tabs-advice nxml-indent-line nxml-child-indent)))))
+    )
+  "Alist of language name and their activation code.
+Smarttabs is enabled in mode hook.")
 
 (defmacro smart-tabs-mode/no-tabs-mode-advice (function)
   `(unless (ad-find-advice ',function 'around 'smart-tabs)
@@ -149,6 +196,50 @@
         (t
          ad-do-it)))))
 
+;;;###autoload
+(defun smart-tabs-insinuate (&rest languages)
+  "Enable smart-tabs-mode for LANGUAGES.
+LANGUAGES is a list of SYMBOL or NAME as defined in
+'smart-tabs-mode-map' alist or a language using standard named
+indent function and indent level.
+"
+  (mapc (lambda (lang)
+           (let ((lang-map (assoc lang smart-tabs-mode-map))
+                 (lang-param (smart-tabs-get-standard-language lang)))
+             (cond ((and (null lang-map)
+                         (not (null (car lang-param)))
+                         (not (null (nth 1 lang-param)))
+                         (not (null (nth 2 lang-param))))
+                    (smart-tabs-guess-insinuate lang-param))
+                   ((null lang-map) (error (format "Unknown smart-tab-mode capable language '%s'" lang)))
+                   (t (funcall (cdr lang-map))))))
+        languages))
+
+(defun smart-tabs-guess-insinuate (lang-param)
+  "Enable smart-tabs-mode if language respect standard naming.
+Several languages define a '<LANGUAGE>-indent-line' function and
+'<LANGUAGE>-indent-level' variable to control indentation.
+LANG-PARAM is a list of HOOK INDENT-FUNCTION INDENT-LEVEL, if
+thoses are defined, we use them."
+  (let ((lang-hook (car lang-param))
+        (indent-function (nth 1 lang-param))
+        (indent-level (nth 2 lang-param)))
+  (if (and (not (null lang-hook))
+           (and (not (null indent-function))
+                (fboundp indent-function))
+           (and (not (null indent-level))
+                (boundp indent-level)))
+      (add-hook lang-hook
+                `(lambda ()
+                    (smart-tabs-mode-enable)
+                    (smart-tabs-advice ,indent-function ,indent-level))))))
+
+(defun smart-tabs-get-standard-language (language)
+  "Return a list of HOOK INDENT-FUNCTION INDENT-LEVEL for a language."
+  (let ((indent-function (intern-soft (concat (symbol-name language) "-indent-line")))
+        (indent-level (intern-soft (concat (symbol-name language) "-indent-level")))
+        (lang-hook (intern-soft (concat (symbol-name language) "-mode-hook"))))
+    (list lang-hook indent-function indent-level)))
 
 (provide 'smart-tabs-mode)
 


### PR DESCRIPTION
Several languages use names in the form "<LANGUAGE>-indent-line" and
"<LANGUAGE>-indent-level".

If a language use these "standard" names, they are used if the language
mode is loaded.
- smart-tabs-mode.el (smart-tabs-mode-map): Alist of language name and
  their code to enable smarttabs.
  (smart-tabs-insinuate): Enable smarttabs for a list of languages or if
  we can guess indent function and indent level.
  (smart-tabs-guess-insinuate): Use standard indent function and indent
  level names.
  (smart-tabs-get-standard-language): Build a list of standard names for
  hook, indent function and indent level.
