### PR TITLE
Fix Localized Variable Alias Bug

### DIFF
--- a/smart-tabs-mode.el
+++ b/smart-tabs-mode.el
@@ -182,7 +182,6 @@ Smarttabs is enabled in mode hook.")
 ;;;###autoload
 (defmacro smart-tabs-advice (function offset)
   `(progn
-     (defvaralias ',offset 'tab-width)
      (defadvice ,function (around smart-tabs activate)
        (cond
         (smart-tabs-mode


### PR DESCRIPTION
Removed `defvaralias` line from `smart-tabs-advice` macro.
