### PR TITLE
Added Macro For Conveniently Setting Entries in `smart-tabs-insinuate-alist`.

### DIFF
--- a/smart-tabs-mode.el
+++ b/smart-tabs-mode.el
@@ -122,12 +122,12 @@
 
 ;;;###autoload
 (defmacro smart-tabs-create-language-advice (lang mode-hook advice-list &rest body)
-	"Create a cons cell containing the actions to take to enable
+  "Create a cons cell containing the actions to take to enable
 `smart-tabs-mode' for the language LANG. This usually involved enabling
 `smart-tabs-mode' through `smart-tabs-mode-enable' and adding a lambda
 function to the MODE-HOOK for the specified language. This macro
 simplifies the creation of such a cons cell."
-	`'(,lang . (lambda ()
+  `'(,lang . (lambda ()
                (add-hook ',mode-hook
                          (lambda ()
                            (smart-tabs-mode-enable)
@@ -144,23 +144,23 @@ simplifies the creation of such a cons cell."
        ((c-indent-line . c-basic-offset)
         (c-indent-region . c-basic-offset)))
 
-		,(smart-tabs-create-language-advice javascript js2-mode-hook
+    ,(smart-tabs-create-language-advice javascript js2-mode-hook
        ((js2-indent-line . js2-basic-offset)))
 
-		,(smart-tabs-create-language-advice cperl cperl-mode-hook
+    ,(smart-tabs-create-language-advice cperl cperl-mode-hook
        ((cperl-indent-line . cperl-indent-level)))
 
-		,(smart-tabs-create-language-advice python python-mode-hook
+    ,(smart-tabs-create-language-advice python python-mode-hook
        ((python-indent-line-1 . python-indent))
        (smart-tabs-when (featurep 'python-mode)
          ((py-indent-line . py-indent-offset)
           (py-newline-and-indent . py-indent-offset)
           (py-indent-region . py-indent-offset))))
 
-		,(smart-tabs-create-language-advice ruby ruby-mode-hook
+    ,(smart-tabs-create-language-advice ruby ruby-mode-hook
        ((ruby-indent-line . ruby-indent-level)))
 
-		,(smart-tabs-create-language-advice nxml nxml-mode-hook
+    ,(smart-tabs-create-language-advice nxml nxml-mode-hook
        ((nxml-indent-line . nxml-child-indent))))
 
   "Alist of language name and their activation code.
@@ -229,15 +229,16 @@ LANGUAGES is a list of SYMBOL or NAME as defined in
 indent function and indent level.
 "
   (mapc (lambda (lang)
-           (let ((lang-map (assoc lang smart-tabs-insinuate-alist))
-                 (lang-param (smart-tabs-get-standard-language lang)))
-             (cond ((and (null lang-map)
-                         (not (null (car lang-param)))
-                         (not (null (nth 1 lang-param)))
-                         (not (null (nth 2 lang-param))))
-                    (smart-tabs-guess-insinuate lang-param))
-                   ((null lang-map) (error (format "Unknown smart-tab-mode capable language '%s'" lang)))
-                   (t (funcall (cdr lang-map))))))
+          (let ((lang-map (assoc lang smart-tabs-insinuate-alist))
+                (lang-param (smart-tabs-get-standard-language lang)))
+            (cond ((and (null lang-map)
+                        (not (null (car lang-param)))
+                        (not (null (nth 1 lang-param)))
+                        (not (null (nth 2 lang-param))))
+                   (smart-tabs-guess-insinuate lang-param))
+                  ((null lang-map)
+                   (error (format "Unknown smart-tab-mode capable language '%s'" lang)))
+                  (t (funcall (cdr lang-map))))))
         languages))
 
 (defun smart-tabs-guess-insinuate (lang-param)
@@ -249,15 +250,15 @@ thoses are defined, we use them."
   (let ((lang-hook (car lang-param))
         (indent-function (nth 1 lang-param))
         (indent-level (nth 2 lang-param)))
-  (if (and (not (null lang-hook))
-           (and (not (null indent-function))
-                (fboundp indent-function))
-           (and (not (null indent-level))
-                (boundp indent-level)))
-      (add-hook lang-hook
-                `(lambda ()
-                    (smart-tabs-mode-enable)
-                    (smart-tabs-advice ,indent-function ,indent-level))))))
+    (if (and (not (null lang-hook))
+             (and (not (null indent-function))
+                  (fboundp indent-function))
+             (and (not (null indent-level))
+                  (boundp indent-level)))
+        (add-hook lang-hook
+                  `(lambda ()
+                     (smart-tabs-mode-enable)
+                     (smart-tabs-advice ,indent-function ,indent-level))))))
 
 (defun smart-tabs-get-standard-language (language)
   "Return a list of HOOK INDENT-FUNCTION INDENT-LEVEL for a language."


### PR DESCRIPTION
I have written a few macros so that entries in the `smart-tabs-insinuate-alist` can be written much more concisely and have changed the definition of `smart-tabs-insinuate-alist` to use them. They take care of inserting all of the boilerplate code so you just specify the language, the mode, and an alist containing `(indent-function . offset)`. I did this so in the future, if anything else needs to be added to the hooks it only needs to be done in one place. I also made sure to set the `lisp-indent-function` so they indent properly.
