### PR TITLE
Language Support, Macro Indentation Fix, and Documentation 

### DIFF
--- a/smart-tabs-mode.el
+++ b/smart-tabs-mode.el
@@ -218,7 +218,7 @@ indent function and indent level.
 
 
 ;;;###autoload
-(defun smart-tabs-add-language-support (lang mode-hook advice-list &rest body)
+(defmacro smart-tabs-add-language-support (lang mode-hook advice-list &rest body)
   "Add support for a language not already in the `smart-tabs-insinuate-alist'."
   (declare (indent 2))
   `(add-to-list


### PR DESCRIPTION
- Added support for C++ and Java by default.
- Macro indentation should be specified with `(declare (indent 'rule))` instead of `put`. My bad (A)
- Added macro for easily adding items to `smart-tabs-insinuate-alist`.
- Updated documentation to reflect changes in use.
- Bumped version to 1.0.
  - I feel that in the current state of the code, it should have a major version update.
- Added myself to author list at the top of the file.
