### PR TITLE
Fixed the define-minor-mode macro so the body is called properly

### DIFF
--- a/smart-tabs-mode.el
+++ b/smart-tabs-mode.el
@@ -213,6 +213,8 @@ Smarttabs is enabled in mode hook.")
 (define-minor-mode smart-tabs-mode
   "Intelligently indent with tabs, align with spaces!"
 
+  :init-value nil
+
   (progn
     (smart-tabs-mode/no-tabs-mode-advice align)
     (smart-tabs-mode/no-tabs-mode-advice align-regexp)


### PR DESCRIPTION
In the define-minor-mode macro where smart-tabs-mode is defined, there
is code to add some advice to integrate smart tabs functionality with
standard library functions (such as align.el). The problem is, Emacs is
expecting optional parameters after the docstring. When it expanded the
define-minor-mode macro, it was inserting this progn as the initial
value of a defvar; in some versions of Emacs (including at least 24.5
and the latest 25 trunk), the progn would be interpreted as a list in
this position and never actually execute, thus the advice would not be
installed.

By adding a :init-value keyword argument to the function, we can force
the argument binding to skip past the optional parameters so the progn
is correctly interpreted as a BODY argument rather than the INIT-VALUE
argument.