### PR TITLE
Quote single quotes in docstrings

### DIFF
--- a/smart-tabs-mode.el
+++ b/smart-tabs-mode.el
@@ -263,7 +263,7 @@ Smarttabs is enabled in mode hook.")
 (defun smart-tabs-insinuate (&rest languages)
   "Enable smart-tabs-mode for LANGUAGES.
 LANGUAGES is a list of SYMBOL or NAME as defined in
-'smart-tabs-insinuate-alist' alist or a language using standard named
+\\='smart-tabs-insinuate-alist\\=' alist or a language using standard named
 indent function and indent level.
 "
   (mapc (lambda (lang)


### PR DESCRIPTION
Silences the following warning in Emacs 29 and newer:

```
⛔ Warning (comp): smart-tabs-mode.el:265:2: Warning: docstring has wrong usage of unescaped single quotes (use \= or different quoting)
```