### PR TITLE
Convert uses of defadvice into define-advice

### DIFF
--- a/smart-tabs-mode.el
+++ b/smart-tabs-mode.el
@@ -204,10 +204,10 @@ Smarttabs is enabled in mode hook.")
 
 (defmacro smart-tabs-mode/no-tabs-mode-advice (function)
   `(unless (ad-find-advice ',function 'around 'smart-tabs)
-     (defadvice ,function (around smart-tabs activate)
+     (define-advice ,function (:around (orig-fun &rest args) smart-tabs)
        (if smart-tabs-mode
-           (let ((indent-tabs-mode nil)) ad-do-it)
-         ad-do-it))))
+           (let ((indent-tabs-mode nil)) (apply orig-fun args))
+         (apply orig-fun args)))))
 
 ;;;###autoload
 (define-minor-mode smart-tabs-mode
@@ -225,15 +225,15 @@ Smarttabs is enabled in mode hook.")
 
     (unless
         (ad-find-advice 'indent-according-to-mode 'around 'smart-tabs)
-      (defadvice indent-according-to-mode (around smart-tabs activate)
+      (define-advice indent-according-to-mode (:around (orig-fun &rest args) smart-tabs)
         (if smart-tabs-mode
             (let ((indent-tabs-mode indent-tabs-mode))
               (if (memq indent-line-function
                         '(indent-relative
                           indent-relative-maybe))
                   (setq indent-tabs-mode nil))
-              ad-do-it)
-          ad-do-it)))
+              (apply orig-fun args))
+          (apply orig-fun args))))
     ))
 
 ;;;###autoload
@@ -244,7 +244,7 @@ Smarttabs is enabled in mode hook.")
 ;;;###autoload
 (defmacro smart-tabs-advice (function offset)
   `(progn
-     (defadvice ,function (around smart-tabs activate)
+     (define-advice ,function (:around (orig-fun &rest args) smart-tabs)
        (cond
         ((and smart-tabs-mode indent-tabs-mode (eq ,offset tab-width))
          (save-excursion
@@ -255,9 +255,9 @@ Smarttabs is enabled in mode hook.")
          (let ((tab-width fill-column)
                (,offset fill-column))
            (unwind-protect
-               (progn ad-do-it))))
+               (progn (apply orig-fun args)))))
         (t
-         ad-do-it)))))
+         (apply orig-fun args))))))
 
 ;;;###autoload
 (defun smart-tabs-insinuate (&rest languages)


### PR DESCRIPTION
As of Emacs 30.1, defadvice is deprecated. Although it still works, loading smart-tabs-mode will now cause an annoying warning in the messages buffer.

This patch rewrites the uses of defadvice into uses of define-advice instead. define-advice is a helper function that combines defun with advice-add, which is the replacement of defadvice. No changes in semantics is expected from this rewrite.